### PR TITLE
ci: migrate to woodpecker

### DIFF
--- a/.github/workflows-disabled/ci.yml
+++ b/.github/workflows-disabled/ci.yml
@@ -1,0 +1,42 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: cargo test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test
+      - run: cargo clippy -- -D warnings
+      - run: cargo fmt --check
+
+  readme-lint:
+    name: readme-lint
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: . -> target
+          cache-key: readme-lint
+      - name: build readme-lint
+        run: |
+          git clone https://github.com/BryanChasko/heraldstack-mcp.git /tmp/heraldstack-mcp
+          cargo build --release --manifest-path /tmp/heraldstack-mcp/tools/readme-lint/Cargo.toml
+      - uses: tj-actions/changed-files@v44
+        id: changed
+        with:
+          files: '**/*.md'
+      - if: steps.changed.outputs.any_changed == 'true'
+        run: /tmp/heraldstack-mcp/tools/readme-lint/target/release/readme-lint ${{ steps.changed.outputs.all_changed_files }}

--- a/.woodpecker/ci.yml
+++ b/.woodpecker/ci.yml
@@ -1,0 +1,21 @@
+steps:
+  test:
+    image: rust:1-slim
+    commands:
+      - cargo test
+      - cargo clippy -- -D warnings
+      - cargo fmt --check
+
+  readme-lint:
+    image: rust:1-slim
+    when:
+      event: pull_request
+    commands:
+      - git clone https://github.com/BryanChasko/heraldstack-mcp.git /tmp/heraldstack-mcp
+      - cargo build --release --manifest-path /tmp/heraldstack-mcp/tools/readme-lint/Cargo.toml
+      - |
+        git fetch origin main:main
+        changed=$(git diff --name-only main HEAD | grep '\.md$' || true)
+        if [ -n "$changed" ]; then
+          /tmp/heraldstack-mcp/tools/readme-lint/target/release/readme-lint $changed
+        fi


### PR DESCRIPTION
## summary

- moved ci workflow from github actions to woodpecker pipeline
- cargo test, clippy (strict), fmt check unified in single step
- readme-lint now pr-gated with changed files detection via git diff

## migrated
- cargo test + cargo clippy + cargo fmt check
- pr-conditional readme-lint step with git-based file filtering

## not migrated
- github actions caching layers (not needed for woodpecker on persistent runner)

## unresolved
- woodpecker endpoint must be registered in ops repo before pull
- assume rocm-aibox runner has rust:1-slim image available